### PR TITLE
fixed Cannot Find Module error in example

### DIFF
--- a/examples/simple.js
+++ b/examples/simple.js
@@ -1,9 +1,11 @@
 var daydream = require('../daydream-node')();
+var readline = require('readline');
 
 daydream.onStateChange(function(data){
-    if(data.isClickDown){
-        console.log('clicking down');
-    } else {
-        console.log('not cliking down');
-    }
-})
+  // output whole data object using JSON.stringify and readline library
+  // (i.e. overwrite output instead of appending)
+  readline.clearScreenDown(process.stdout);
+  process.stdout.write(JSON.stringify(data, null, 2));
+  readline.moveCursor(process.stdout, null, -19);
+  readline.cursorTo(process.stdout, 0);
+});

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -1,4 +1,4 @@
-var daydream = require('daydream-node')();
+var daydream = require('../daydream-node')();
 
 daydream.onStateChange(function(data){
     if(data.isClickDown){


### PR DESCRIPTION
The example doesn't work for me without this relative path; throws the following error:
```
daydream-node$ node examples/simple.js
module.js:557
    throw err;
    ^

Error: Cannot find module 'daydream-node'
    at Function.Module._resolveFilename (module.js:555:15)
    at Function.Module._load (module.js:482:25)
    at Module.require (module.js:604:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/Users/textchimp/Documents/build/scratch/daydream-node/examples/simple.js:1:78)
    at Module._compile (module.js:660:30)
    at Object.Module._extensions..js (module.js:671:10)
    at Module.load (module.js:573:32)
    at tryModuleLoad (module.js:513:12)
    at Function.Module._load (module.js:505:3)
```

Also added some nice output of the whole data object.

I guess the script should tell the user what to do to make the connection, i.e. you have to press the home button...